### PR TITLE
Container updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ exec-tests-integration:
 exec-tests-unit:
 	docker compose --file=development/tests-docker-compose.yml exec tests-runner make tests-unit
 
+stop:
+	docker compose --file=development/docker-compose.yml stop
+
 down:
 	docker compose --file=development/docker-compose.yml down --remove-orphans --volumes
 
@@ -84,6 +87,7 @@ git-diff:
 	exec-tests-vendor \
 	exec-tests-integration \
 	exec-tests-unit \
+	stop \
 	down \
 	down-tests \
 	code \

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -11,6 +11,6 @@ services:
     tty: true
     volumes:
       - ./../:/root/app
-      - ./../development/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
+      - ./php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini:ro
     ports:
       - '127.0.0.1:9009:9009'

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       target: develop
       provenance: false
       sbom: false
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
     init: true
     tty: true
     volumes:

--- a/development/tests-docker-compose.yml
+++ b/development/tests-docker-compose.yml
@@ -12,6 +12,11 @@ services:
         - type=gha
       cache_to:
         - type=gha,mode=max
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    init: true
     tty: true
     volumes:
       - ./../:/root/app


### PR DESCRIPTION
- Added `cap_drop: ALL` and `security_opt: no-new-privileges=true` settings to the `development/docker-compose.yml` and `development/tests-docker-compose.yml` files for improving security. [GitHub doc](https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support) suggests not using the `USER` in `Dockerfile`.
- Use [tini](https://github.com/krallin/tini) for the `development/tests-docker-compose.yml` as we do in the `development/docker-compose.yml`.
- Added `make stop` target for stopping local development container.
- Simplified the path for `xdebug.ini`.