### PR TITLE
Run php-cs-fixer in container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,31 +50,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up the PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          ini-file: development
-          extensions: filter, libxml, tokenizer, xmlreader, iconv, mbstring
-          tools: composer
-
-      - name: Detect Composer Cache Directory
-        id: composer-cache
-        run: 'echo "cache-files-dir=$(composer config cache-files-dir --global)" >> $GITHUB_OUTPUT'
-
-      - name: Composer Cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ${{ steps.composer-cache.outputs.cache-files-dir }}
-            vendor
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Composer Install
-        run: 'make vendor'
-
       - name: PHP Coding Standards Cache
         uses: actions/cache@v5
         with:
@@ -84,8 +59,26 @@ jobs:
           restore-keys: |
             phpcs-
 
-      - name: PHP Coding Standards
-        run: 'make php-cs-fixer-check'
+      - name: Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          cleanup: true
+
+      - name: Docker Bake
+        uses: docker/bake-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          files: development/docker-compose-tests.yml
+          source: ./
+          targets: php-cs-fixer
+
+      - name: Docker Compose Up. PHP Coding Standards
+        run: make up-php-cs-fixer
+
+      - name: Docker Compose Down
+        if: always()
+        run: make down-tests
 
   psalm:
     name: Psalm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 SHELL := /bin/bash
 
+ifeq ($(GITHUB_ACTIONS),true)
+	PHP_CS_FIXER_SHOW_PROGRESS := none
+else
+	PHP_CS_FIXER_SHOW_PROGRESS := bar
+endif
+
 build:
 	docker compose --file development/docker-compose.yml build
 
@@ -108,7 +114,8 @@ php-cs-fixer-check:
 		--config="development/php-cs-fixer/php-cs-fixer.dist.php" \
 		--cache-file="development/php-cs-fixer/php-cs-fixer.cache" \
 		--format=@auto \
-		--no-interaction
+		--no-interaction \
+		--show-progress=$(PHP_CS_FIXER_SHOW_PROGRESS)
 
 php-syntax:
 	find . -type f -name "*.php" \( -path "./source/*" -o -path "./grammar/*" \) -print0 \

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,22 @@ up-psalm:
 		--attach=psalm \
 		psalm
 
+up-php-cs-fixer:
+	docker compose \
+		--file=development/docker-compose-tests.yml \
+		up \
+		--no-build \
+		--quiet-pull \
+		--remove-orphans \
+		--timeout=120 \
+		--wait-timeout=120 \
+		--yes \
+		--abort-on-container-failure \
+		--no-log-prefix \
+		--exit-code-from=php-cs-fixer \
+		--attach=php-cs-fixer \
+		php-cs-fixer
+
 stop:
 	docker compose --file=development/docker-compose.yml stop
 
@@ -131,6 +147,7 @@ git-diff:
 	up-tests-integration \
 	up-tests-unit \
 	up-psalm \
+	up-php-cs-fixer \
 	stop \
 	down \
 	down-tests \

--- a/development/containers/php/Dockerfile
+++ b/development/containers/php/Dockerfile
@@ -43,6 +43,10 @@ FROM tests-runner AS psalm
 
 ENTRYPOINT ["make", "psalm"]
 
+FROM tests-runner AS php-cs-fixer
+
+ENTRYPOINT ["make", "php-cs-fixer-check"]
+
 FROM base AS develop
 
 RUN pecl install xdebug

--- a/development/docker-compose-tests.yml
+++ b/development/docker-compose-tests.yml
@@ -65,3 +65,19 @@ services:
       - ./../source:/home/php/app/source:read-only
       - ./../tests:/home/php/app/tests:read-only
       - ./../Makefile:/home/php/app/Makefile:read-only
+
+  php-cs-fixer:
+    <<: *service-php
+    build:
+      <<: *service-php-build
+      target: php-cs-fixer
+      tags:
+        - srt-reader-php-cs-fixer:latest
+    volumes:
+      - ./../development:/home/php/app/development
+      - ./../grammar:/home/php/app/grammar:read-only
+      - ./../source:/home/php/app/source:read-only
+      - ./../tests:/home/php/app/tests:read-only
+      - ./../Makefile:/home/php/app/Makefile:read-only
+      - ./../composer.json:/home/php/app/composer.json:read-only
+      - ./../composer.lock:/home/php/app/composer.lock:read-only

--- a/development/docker-compose-tests.yml
+++ b/development/docker-compose-tests.yml
@@ -73,6 +73,8 @@ services:
       target: php-cs-fixer
       tags:
         - srt-reader-php-cs-fixer:latest
+    environment:
+      GITHUB_ACTIONS: ${GITHUB_ACTIONS:-false}
     volumes:
       - ./../development:/home/php/app/development
       - ./../grammar:/home/php/app/grammar:read-only


### PR DESCRIPTION
Run php-cs-fixer in container in GitHub CI. The `development/containers/php/Dockerfile` is the same as for unit, integration tests and Psalm.